### PR TITLE
Add queued mail jobs and analytics

### DIFF
--- a/app/Http/Controllers/NewsletterController.php
+++ b/app/Http/Controllers/NewsletterController.php
@@ -2,10 +2,9 @@
 
 namespace App\Http\Controllers;
 
-use App\Mail\ConfirmationMail;
+use App\Jobs\SendConfirmationEmail;
 use App\Models\Subscriber;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Mail;
 
 class NewsletterController extends Controller
 {
@@ -25,7 +24,7 @@ class NewsletterController extends Controller
             ['confirm_token' => str()->random(40)]
         );
 
-        Mail::to($subscriber->email)->send(new ConfirmationMail($subscriber->confirm_token));
+        SendConfirmationEmail::dispatch($subscriber->email, $subscriber->confirm_token);
 
         return redirect()->back()->with('status', 'Please check your email to confirm subscription.');
     }

--- a/app/Jobs/SendCampaignEmail.php
+++ b/app/Jobs/SendCampaignEmail.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Mail\CampaignMail;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use App\Models\Campaign;
+
+class SendCampaignEmail implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public Campaign $campaign,
+        public string $email,
+        public int $pivotId
+    ) {
+    }
+
+    public function handle(): void
+    {
+        Mail::to($this->email)->send(new CampaignMail($this->campaign, $this->pivotId));
+        DB::table('campaign_subscriber')->where('id', $this->pivotId)->update(['sent_at' => now()]);
+    }
+}

--- a/app/Jobs/SendConfirmationEmail.php
+++ b/app/Jobs/SendConfirmationEmail.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Mail\ConfirmationMail;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Mail;
+
+class SendConfirmationEmail implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public string $email, public string $token)
+    {
+    }
+
+    public function handle(): void
+    {
+        Mail::to($this->email)->send(new ConfirmationMail($this->token));
+    }
+}

--- a/app/Services/CampaignMailer.php
+++ b/app/Services/CampaignMailer.php
@@ -2,9 +2,8 @@
 
 namespace App\Services;
 
-use App\Mail\CampaignMail;
+use App\Jobs\SendCampaignEmail;
 use App\Models\Campaign;
-use Illuminate\Support\Facades\Mail;
 
 class CampaignMailer
 {
@@ -12,9 +11,7 @@ class CampaignMailer
     {
         $campaign->load('subscribers');
         foreach ($campaign->subscribers as $subscriber) {
-            // dd($subscriber->pivot->id);
-            Mail::to($subscriber->email)->send(new CampaignMail($campaign, $subscriber->pivot->id));
-            $subscriber->pivot->update(['sent_at' => now()]);
+            SendCampaignEmail::dispatch($campaign, $subscriber->email, $subscriber->pivot->id);
         }
 
         $campaign->update(['status' => 'sent']);

--- a/resources/views/admin/layout/sidebar_menu.blade.php
+++ b/resources/views/admin/layout/sidebar_menu.blade.php
@@ -62,16 +62,22 @@
                          </div>
                      </li>
                  @endif
-                 <li class="{{ request()->routeIs('products.*') ? 'menuitem-active' : '' }}">
-                     <a href='{{ route('products.index') }}'>
-                         <i data-feather="book-open"></i>
-                         <span> Products </span>
-                     </a>
-                 </li>
-                 <li>
-                     <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
-                         @csrf
-                     </form>
+                <li class="{{ request()->routeIs('products.*') ? 'menuitem-active' : '' }}">
+                    <a href='{{ route('products.index') }}'>
+                        <i data-feather="book-open"></i>
+                        <span> Products </span>
+                    </a>
+                </li>
+                <li class="{{ request()->routeIs('campaign.analytics') ? 'menuitem-active' : '' }}">
+                    <a href='{{ route('campaign.analytics') }}'>
+                        <i data-feather="bar-chart-2"></i>
+                        <span> Mail Analytics </span>
+                    </a>
+                </li>
+                <li>
+                    <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
+                        @csrf
+                    </form>
 
                      <a href="#" class="text-danger"
                          onclick="event.preventDefault(); document.getElementById('logout-form').submit();">

--- a/resources/views/campaign/analytics.blade.php
+++ b/resources/views/campaign/analytics.blade.php
@@ -1,0 +1,31 @@
+@extends('admin.layout.master')
+
+@section('content')
+<div class="container py-5">
+    <h2 class="mb-4">Campaign Analytics</h2>
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            <table class="table mb-0">
+                <thead class="table-light">
+                    <tr>
+                        <th>Subject</th>
+                        <th>Sent</th>
+                        <th>Opens</th>
+                        <th>Clicks</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($campaigns as $campaign)
+                        <tr>
+                            <td>{{ $campaign->subject }}</td>
+                            <td>{{ $campaign->sent_count }}</td>
+                            <td>{{ $campaign->open_count }}</td>
+                            <td>{{ $campaign->click_count }}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/emails/campaign.blade.php
+++ b/resources/views/emails/campaign.blade.php
@@ -77,6 +77,9 @@
         <div class="content">
             <h1 class="subject">{{ $campaign->subject }}</h1>
             <div class="body"> {!! nl2br(e($campaign->body)) !!} </div>
+            <div class="my-4 text-center">
+                <a href="{{ route('campaign.click', $pivotId) }}" style="background:#4299e1;color:#fff;padding:10px 20px;border-radius:6px;text-decoration:none;display:inline-block">Visit Site</a>
+            </div>
             <div class="footer"> Thanks,<br> <span class="signature">{{ config('app.name') }}</span> </div>
         </div>
     </div> {{-- Tracking Pixel --}} <img src="{{ route('campaign.open', $pivotId) }}" alt="" width="1"

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,6 +42,7 @@ Route::get('/newsletter/subscribe', [NewsletterController::class, 'subscribeForm
 Route::post('/newsletter/subscribe', [NewsletterController::class, 'subscribe'])->name('newsletter.subscribe');
 Route::get('/newsletter/confirm/{token}', [NewsletterController::class, 'confirm'])->name('newsletter.confirm');
 Route::get('/campaign/open/{pivot}', [CampaignController::class, 'open'])->name('campaign.open');
+Route::get('/campaign/click/{pivot}', [CampaignController::class, 'click'])->name('campaign.click');
 
 require __DIR__ . '/auth.php';
 
@@ -126,6 +127,7 @@ Route::group(['prefix' => 'dashboard', 'middleware' => ['auth', 'role:admin']], 
 
     Route::resource('campaign', CampaignController::class)->only(['index','create','store']);
     Route::post('campaign/{campaign}/send', [CampaignController::class, 'send'])->name('campaign.send');
+    Route::get('campaign/analytics', [CampaignController::class, 'analytics'])->name('campaign.analytics');
 });
 Route::group(['prefix' => 'dashboard', 'middleware' => ['auth', 'role:user|admin']], function () {
 


### PR DESCRIPTION
## Summary
- queue campaign mail sending with a job
- queue confirmation mail sending with a job
- track campaign link clicks
- show campaign analytics page for admin
- link analytics in admin sidebar
- add email button and tracking link
- provide blank pixel image for open tracking
- remove binary blank.png and generate pixel in controller
